### PR TITLE
standardImplementation Fix

### DIFF
--- a/backend-lambda/index.js
+++ b/backend-lambda/index.js
@@ -17,8 +17,11 @@ export const handler = async (event, context) => {
     if (!pool) {
       const connectionString = process.env.DATABASE_URL;
       pool = new pg.Pool({
-        connectionString,
-        max: 3,
+        user: process.env.user,
+        database: process.env.database,
+        host: process.env.host,
+        password: process.env.password,
+        port: process.env.port,
       });
     }
   } catch (e) {

--- a/backend-lambda/index.js
+++ b/backend-lambda/index.js
@@ -19,11 +19,6 @@ export const handler = async (event, context) => {
       console.log(process.env);
       pool = new pg.Pool({
         connectionString: connectionString,
-        user: process.env.user,
-        database: process.env.database,
-        host: process.env.host,
-        password: process.env.password,
-        port: process.env.port,
       });
     }
   } catch (e) {

--- a/backend-lambda/index.js
+++ b/backend-lambda/index.js
@@ -16,7 +16,6 @@ export const handler = async (event, context) => {
   try {
     if (!pool) {
       const connectionString = process.env.DATABASE_URL;
-      console.log(process.env);
       pool = new pg.Pool({
         connectionString: connectionString,
       });

--- a/template.yml
+++ b/template.yml
@@ -9,16 +9,6 @@ Globals:
   Function:
     Timeout: 30
     MemorySize: 256
-  standardImplementation:
-    responses:
-      "200":
-        description: "Successful response"
-      "400":
-        description: "Bad request"
-    x-amazon-apigateway-integration:
-      uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BackendLambda.Arn}/invocations"
-      httpMethod: "POST"
-      type: "aws_proxy"
 
 Parameters:
   IpRange:
@@ -72,6 +62,16 @@ Resources:
         info:
           title: "RestApi"
         paths:
+          &standardImplementation:
+            responses:
+              "200":
+                description: "Successful response"
+              "400":
+                description: "Bad request"
+            x-amazon-apigateway-integration:
+              uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BackendLambda.Arn}/invocations"
+              httpMethod: "POST"
+              type: "aws_proxy"
           /products:
             get: *standardImplementation
             post: *standardImplementation

--- a/template.yml
+++ b/template.yml
@@ -50,6 +50,12 @@ Resources:
       Environment:
         Variables:
           DATABASE_URL: !Ref DatabaseUrl
+      Events:
+        RestApi:
+          Type: Api
+          Properties:
+            Path: /
+            Method: ANY
 
   RestApi:
     Type: AWS::Serverless::Api
@@ -68,6 +74,8 @@ Resources:
                 description: "Successful response"
               "400":
                 description: "Bad request"
+              "500":
+                description: "Server error"
             x-amazon-apigateway-integration:
               uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BackendLambda.Arn}/invocations"
               httpMethod: "POST"

--- a/template.yml
+++ b/template.yml
@@ -62,26 +62,25 @@ Resources:
     Properties:
       StageName: prod
       Auth:
-        DefaultAuthorizer: !Ref IpAuthorizerLambdaFunction
+        DefaultAuthorizer: !Ref IpAuthorizerLambda
       DefinitionBody:
         swagger: "2.0"
         info:
           title: "RestApi"
         paths:
-          &standardImplementation:
-            responses:
-              "200":
-                description: "Successful response"
-              "400":
-                description: "Bad request"
-              "500":
-                description: "Server error"
-            x-amazon-apigateway-integration:
-              uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BackendLambda.Arn}/invocations"
-              httpMethod: "POST"
-              type: "aws_proxy"
           /products:
-            get: *standardImplementation
+            get: &standardImplementation
+              responses:
+                "200":
+                  description: "Successful response"
+                "400":
+                  description: "Bad request"
+                "500":
+                  description: "Server error"
+              x-amazon-apigateway-integration:
+                uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BackendLambda.Arn}/invocations"
+                httpMethod: "POST"
+                type: "aws_proxy"
             post: *standardImplementation
           /product:
             put: *standardImplementation


### PR DESCRIPTION
- Moved &standardImplementation from globals to paths as it's not a valid global for AWS SAM
- Changed events under backendlambda to handle ANY events with "/" as base path